### PR TITLE
Release/1.0.1-incorrect json error validation

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -38,7 +38,7 @@
           if (nestedKeysArray.length > 1) {
             var data = pagedTotalData.fieldRows[0][$scope.config.customModuleField].value;
             nestedKeysArray.forEach(function (value) {
-              data = data[value];
+              data = CommonUtils.isUndefined(data) ? undefined : data[value];
             })
             $scope.config.moduleList.push({ 'title': layer.title, 'data': data })
           }

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -43,7 +43,8 @@
             $scope.config.moduleList.push({ 'title': layer.title, 'data': data })
           }
           else {
-            var data = pagedTotalData.fieldRows[0][$scope.config.customModuleField].value[layer.value];
+            var data = CommonUtils.isUndefined(pagedTotalData.fieldRows[0][$scope.config.customModuleField].value) ? undefined : 
+                        pagedTotalData.fieldRows[0][$scope.config.customModuleField].value[layer.value];
             $scope.config.moduleList.push({ 'title': layer.title, 'data': data })
           }
         });


### PR DESCRIPTION
Issue- On saving the dashboard, if the record's json field has incorrect json then no error is displayed and no funnel chart is displayed.
Fix- As per other conditions if data is incorrect or not available Question mark (❓ )is added 

Mantis - https://mantis.fortinet.com/bug_view_page.php?bug_id=0907273
<img width="222" alt="Screenshot 2023-04-27 at 2 27 35 PM" src="https://user-images.githubusercontent.com/92782495/234840185-23df8eac-e63b-42d9-84d3-8a8e8d499678.png">
